### PR TITLE
fix warnings on rustc 1.4.0-nightly (10d69db0a 2015-08-23) (RFC 1214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.6.1]
+
+### Fixed
+
+- Decodable must be inherit from Sized. See Rust [RFC #1214](https://github.com/nikomatsakis/rfcs/blob/projection-and-lifetimes/text/0000-projections-lifetimes-and-wf.md#impact-on-cratesio).
+
 ## [0.6.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "utp"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Ricardo Martins <ricardo@scarybox.net>"]
 
 description = "A µTP (Micro/uTorrent Transport Library) library implemented in Rust"

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -38,7 +38,7 @@ pub trait Encodable {
 }
 
 /// A trait for objects that can be decoded from slices of bytes.
-pub trait Decodable {
+pub trait Decodable: Sized {
     /// Decodes a slice of bytes and returns an equivalent object.
     ///
     /// If the slice of bytes represents a valid instance of the type, it returns `Ok`, containing


### PR DESCRIPTION
Decodable must inherit Sized. See [this](https://github.com/nikomatsakis/rfcs/blob/projection-and-lifetimes/text/0000-projections-lifetimes-and-wf.md#impact-on-cratesio).