### PR TITLE
Adds peer_addr fn to UtpSocket

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -249,6 +249,11 @@ impl UtpSocket {
         self.socket.local_addr()
     }
 
+    /// Returns the socket address of the remote peer of this Utp connection.
+    pub fn peer_addr(&self) -> SocketAddr {
+        self.connected_to
+    }
+
     /// Opens a connection to a remote host by hostname or IP address.
     ///
     /// The address type can be any implementer of the `ToSocketAddr` trait. See its documentation


### PR DESCRIPTION
A corresponding function to the [`TcpStream::peer_addr`](https://doc.rust-lang.org/nightly/std/net/struct.TcpStream.html#method.peer_addr) but returns `SocketAddr` directly (not wrapped in `Result`) as it always appears to be set to the correct value.