### PR TITLE
fixes Windows build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,4 +78,6 @@ mod bit_iterator;
 mod packet;
 mod socket;
 mod stream;
+#[cfg(windows)]
+mod select;
 mod with_read_timeout;

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,0 +1,33 @@
+// Most of the following was copied from 'rust/src/libstd/sys/windows/net.rs'
+use libc;
+
+pub const FD_SETSIZE: usize = 64;
+
+#[repr(C)]
+pub struct fd_set {
+    fd_count: libc::c_uint,
+    fd_array: [libc::SOCKET; FD_SETSIZE],
+}
+
+pub fn fd_set(set: &mut fd_set, s: libc::SOCKET) {
+    set.fd_array[set.fd_count as usize] = s;
+    set.fd_count += 1;
+}
+
+impl fd_set {
+    pub fn new() -> fd_set {
+        fd_set {
+            fd_count: 0,
+            fd_array: [0; FD_SETSIZE],
+        }
+    }
+}
+
+#[link(name = "ws2_32")]
+extern "system" {
+    pub fn select(nfds: libc::c_int,
+                  readfds: *mut fd_set,
+                  writefds: *mut fd_set,
+                  exceptfds: *mut fd_set,
+                  timeout: *mut libc::timeval) -> libc::c_int;
+}


### PR DESCRIPTION
The fixed error is:

    src\with_read_timeout.rs:40:13: 40:19 error: unresolved import `select::fd_set`. Maybe a missing `extern crate select`? [E0432]
    src\with_read_timeout.rs:40         use select::fd_set;
                                            ^~~~~~
    src\with_read_timeout.rs:40:13: 40:19 help: run `rustc --explain E0432` to see a detailed explanation
    error: aborting due to previous error

Introduced in commit dfd91141a0c864bd939d9e0f9cd2ff578aeea2f8

Hint taken from
https://github.com/maidsafe/rust-utp/commit/c7a7190b53488cc1f132bc55a6686c3990370409#diff-b4aea3e418ccdb71239b96952d9cddb6R81