### PR TITLE
Improve examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,27 +46,18 @@ The simplest example program would be:
 extern crate utp;
 
 use utp::UtpStream;
-use std::io::{Read, Write};
+use std::io::Write;
 
 fn main() {
     // Connect to an hypothetical local server running on port 8080
     let addr = "127.0.0.1:8080";
-    let mut stream = match UtpStream::connect(addr) {
-        Ok(stream) => stream,
-        Err(e) => panic!("{}", e),
-    };
+    let mut stream = UtpStream::connect(addr).expect("Error connecting to remote peer");
 
     // Send a string
-    match stream.write("Hi there!".as_bytes()) {
-        Ok(_) => (),
-        Err(e) => println!("Write failed with {}", e)
-    }
+    stream.write("Hi there!".as_bytes()).expect("Write failed");
 
     // Close the stream
-    match stream.close() {
-        Ok(()) => println!("Connection closed"),
-        Err(e) => println!("{}", e)
-    }
+    stream.close().expect("Error closing connection");
 }
 ```
 

--- a/examples/echo-server.rs
+++ b/examples/echo-server.rs
@@ -19,11 +19,11 @@ fn handle_client(mut s: UtpSocket) {
 
 fn main() {
     // Start logger
-    env_logger::init().unwrap();
+    env_logger::init().expect("Error starting logger");
 
     // Create a listener
     let addr = "127.0.0.1:8080";
-    let listener = UtpListener::bind(addr).unwrap();
+    let listener = UtpListener::bind(addr).expect("Error binding listener");
 
     for connection in listener.incoming() {
         // Spawn a new handler for each new connection

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,27 +23,18 @@
 //! extern crate utp;
 //!
 //! use utp::UtpStream;
-//! use std::io::{Read, Write};
+//! use std::io::Write;
 //!
 //! fn main() {
 //!     // Connect to an hypothetical local server running on port 8080
 //!     let addr = "127.0.0.1:8080";
-//!     let mut stream = match UtpStream::connect(addr) {
-//!         Ok(stream) => stream,
-//!         Err(e) => panic!("{}", e),
-//!     };
+//!     let mut stream = UtpStream::connect(addr).expect("Error connecting to remote peer");
 //!
 //!     // Send a string
-//!     match stream.write("Hi there!".as_bytes()) {
-//!         Ok(_) => (),
-//!         Err(e) => println!("Write failed with {}", e)
-//!     }
+//!     stream.write("Hi there!".as_bytes()).expect("Write failed");
 //!
 //!     // Close the stream
-//!     match stream.close() {
-//!         Ok(()) => println!("Connection closed"),
-//!         Err(e) => println!("{}", e)
-//!     }
+//!     stream.close().expect("Error closing connection");
 //! }
 //! ```
 //!
@@ -51,7 +42,7 @@
 //!
 //! ```no_run
 //! # use utp::{UtpStream, UtpSocket};
-//! let socket = UtpSocket::bind("0.0.0.0:0").unwrap();
+//! let socket = UtpSocket::bind("0.0.0.0:0").expect("Error binding socket");
 //! let stream: UtpStream = socket.into();
 //! ```
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -96,14 +96,14 @@ fn take_address<A: ToSocketAddrs>(addr: A) -> Result<SocketAddr> {
 /// ```no_run
 /// use utp::UtpSocket;
 ///
-/// let mut socket = UtpSocket::bind("127.0.0.1:1234").unwrap();
+/// let mut socket = UtpSocket::bind("127.0.0.1:1234").expect("Error binding socket");
 ///
 /// let mut buf = [0; 1000];
-/// let (amt, _src) = socket.recv_from(&mut buf).ok().unwrap();
+/// let (amt, _src) = socket.recv_from(&mut buf).expect("Error receiving");
 ///
 /// let mut buf = &mut buf[..amt];
 /// buf.reverse();
-/// let _ = socket.send_to(buf).unwrap();
+/// let _ = socket.send_to(buf).expect("Error sending");
 ///
 /// // Close the socket. You can either call `close` on the socket,
 /// // explicitly drop it or just let it go out of scope.
@@ -1120,7 +1120,7 @@ impl Drop for UtpSocket {
 /// fn main() {
 ///     // Create a listener
 ///     let addr = "127.0.0.1:8080";
-///     let listener = UtpListener::bind(addr).unwrap();
+///     let listener = UtpListener::bind(addr).expect("Error binding socket");
 ///
 ///     for connection in listener.incoming() {
 ///         // Spawn a new handler for each new connection

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1124,9 +1124,8 @@ impl Drop for UtpSocket {
 ///
 ///     for connection in listener.incoming() {
 ///         // Spawn a new handler for each new connection
-///         match connection {
-///             Ok((socket, _src)) => { thread::spawn(move || { handle_client(socket) }); },
-///             _ => ()
+///         if let Ok((socket, _src)) = connection {
+///             thread::spawn(move || handle_client(socket));
 ///         }
 ///     }
 /// }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -19,7 +19,7 @@ use socket::UtpSocket;
 /// use utp::UtpStream;
 /// use std::io::{Read, Write};
 ///
-/// let mut stream = UtpStream::bind("127.0.0.1:1234").unwrap();
+/// let mut stream = UtpStream::bind("127.0.0.1:1234").expect("Error binding stream");
 /// let _ = stream.write(&[1]);
 /// let _ = stream.read(&mut [0; 1000]);
 /// ```


### PR DESCRIPTION
Improve code examples in README and module documentation.

The improvements require `result_expect` (rust-lang/rust#27277), which is available on Rust 1.4 onwards. Merge only when 1.4 is released as stable.
