### PR TITLE
Adds failing test test_data_exchange_utp

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -2515,4 +2515,60 @@ mod test {
         }
         assert!(child.join().is_ok());
     }
+
+    // Test data exchange
+    #[test]
+    fn test_data_exchange_utp() {
+        let listener = iotry!(UtpListener::bind("127.0.0.1:0"));
+        let server_addr = iotry!(listener.local_addr());
+
+        static TX_BUF: [u8; 10] = [0,1,2,3,4,5,6,7,8,9];
+
+        let client_t = thread::spawn(move || {
+            let mut client = iotry!(UtpSocket::connect(server_addr));
+            assert_eq!(iotry!(client.send_to(&TX_BUF)), TX_BUF.len());
+            let mut buf = [0; 10];
+            iotry!(client.recv_from(&mut buf));
+            assert_eq!(buf, TX_BUF);
+        });
+
+        let mut server = iotry!(listener.accept()).0;
+
+        assert_eq!(iotry!(server.send_to(&TX_BUF)), TX_BUF.len());
+        let mut buf = [0; 10];
+        iotry!(server.recv_from(&mut buf));
+        assert_eq!(buf, TX_BUF);
+
+        assert!(client_t.join().is_ok());
+    }
+
+    /// Analogous to the above, but with TCP sockets.
+    #[test]
+    fn test_data_exchange_tcp() {
+        use std::net::{TcpListener, TcpStream};
+        use std::io::{Read, Write};
+
+        static TX_BUF: [u8; 10] = [0,1,2,3,4,5,6,7,8,9];
+
+        let listener = iotry!(TcpListener::bind("127.0.0.1:0"));
+        let server_addr = iotry!(listener.local_addr());
+
+        let client_t = thread::spawn(move || {
+            let mut client = iotry!(TcpStream::connect(server_addr));
+            assert_eq!(iotry!(client.write(&TX_BUF)), TX_BUF.len());
+            let mut buf = [0; 10];
+            iotry!(client.read(&mut buf));
+            assert_eq!(buf, TX_BUF);
+        });
+
+        let mut server = iotry!(listener.accept()).0;
+
+        assert_eq!(iotry!(server.write(&TX_BUF)), TX_BUF.len());
+        let mut buf = [0; 10];
+        iotry!(server.read(&mut buf));
+        assert_eq!(buf, TX_BUF);
+
+        assert!(client_t.join().is_ok());
+    }
+
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -852,6 +852,7 @@ impl UtpSocket {
                 self.connected_to = src;
                 self.ack_nr = packet.seq_nr();
                 self.seq_nr = rand::random();
+                self.last_acked = self.seq_nr.wrapping_sub(1);
                 self.receiver_connection_id = packet.connection_id() + 1;
                 self.sender_connection_id = packet.connection_id();
                 self.state = SocketState::Connected;


### PR DESCRIPTION
Also adds a passing test test_data_exchange_tcp for comparison.

The uTP test sometimes passes so needs to be run in a loop to make sure it is reproduced. When it passes, it sometimes does so quickly, but it often it takes ~10 seconds to finish.

When it fails, it looks something like this:

```
test socket::test::test_data_exchange_utp ... thread '<unnamed>' panicked at 'Error { repr: Custom(Custom { kind: TimedOut, error: StringError("Connection timed out") }) }', src/socket.rs:2531
stack backtrace:
   1:     0x7fea7da65540 - sys::backtrace::tracing::imp::write::h5839347184a363c1Tnt
   2:     0x7fea7da67b45 - panicking::log_panic::_<closure>::closure.39955
   3:     0x7fea7da67591 - panicking::log_panic::hcde6d42710304abbWnx
   4:     0x7fea7da56da3 - sys_common::unwind::begin_unwind_inner::h4039843fef6bffefYgs
   5:     0x7fea7da57418 - sys_common::unwind::begin_unwind_fmt::hbbea9d3fc97574084fs
   6:     0x7fea7d9fe3e5 - socket::test::test_data_exchange_utp::_<closure>::closure.19345
                        at /home/peter/work/rust/rust-utp/<std macros>:8
   7:     0x7fea7d9fd61c - std::thread::_<impl>::spawn::_<closure>::_<closure>::closure.19340
                        at ../src/libstd/thread/mod.rs:271
   8:     0x7fea7d9fd5d9 - sys_common::unwind::try::try_fn::try_fn::h1429149916602116162
                        at ../src/libstd/sys/common/unwind/mod.rs:156
   9:     0x7fea7da64a78 - __rust_try
  10:     0x7fea7da611eb - sys_common::unwind::try::inner_try::h81e998e565f2181dwds
  11:     0x7fea7d9fd586 - sys_common::unwind::try::try::h5500681879419574301
                        at ../src/libstd/sys/common/unwind/mod.rs:126
  12:     0x7fea7d9fd3fd - std::thread::_<impl>::spawn::_<closure>::closure.19337
                        at ../src/libstd/thread/mod.rs:271
  13:     0x7fea7d9fe79c - boxed::_<impl>::call_box::call_box::h6452290943018104200
                        at ../src/liballoc/boxed.rs:521
  14:     0x7fea7da66633 - sys::thread::_<impl>::new::thread_start::h0be42f811434f5398Fw
  15:     0x7fea7ca066a9 - start_thread
  16:     0x7fea7d22feec - clone
  17:                0x0 - <unknown>
thread 'socket::test::test_data_exchange_utp' panicked at 'assertion failed: client_t.join().is_ok()', src/socket.rs:2542
stack backtrace:
   1:     0x7fea7da65540 - sys::backtrace::tracing::imp::write::h5839347184a363c1Tnt
   2:     0x7fea7da67b45 - panicking::log_panic::_<closure>::closure.39955
   3:     0x7fea7da67591 - panicking::log_panic::hcde6d42710304abbWnx
   4:     0x7fea7da56da3 - sys_common::unwind::begin_unwind_inner::h4039843fef6bffefYgs
   5:     0x7fea7d9441c7 - sys_common::unwind::begin_unwind::begin_unwind::h7653023640623241003
                        at ../src/libstd/sys/common/unwind/mod.rs:224
   6:     0x7fea7d9fc6e7 - socket::test::test_data_exchange_utp::h1d6c8c8760628933ibj
                        at /home/peter/work/rust/rust-utp/<std macros>:3
   7:     0x7fea7da3a2a6 - boxed::_<impl>::call_box::call_box::h575065112849089642
   8:     0x7fea7da3cc7f - sys_common::unwind::try::try_fn::try_fn::h2198980327506938284
   9:     0x7fea7da64a78 - __rust_try
  10:     0x7fea7da611eb - sys_common::unwind::try::inner_try::h81e998e565f2181dwds
  11:     0x7fea7da3d010 - boxed::_<impl>::call_box::call_box::h15791639090073025805
  12:     0x7fea7da66633 - sys::thread::_<impl>::new::thread_start::h0be42f811434f5398Fw
  13:     0x7fea7ca066a9 - start_thread
  14:     0x7fea7d22feec - clone
  15:                0x0 - <unknown>
```

I'm using `Ubuntu 15.04` and `rustc 1.6.0-nightly (1a2eaffb6 2015-10-31)`.