### PR TITLE
Replace time with std::time. Don't overflow when calculating microsec…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ env_logger = "0.3"
 log = "0.3"
 num = "0.1.27"
 rand = "0.3"
-time = "0.1.32"
 
 [dev-dependencies]
 quickcheck = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,6 @@
 #![deny(missing_docs)]
 
 extern crate rand;
-extern crate time;
 extern crate num;
 #[macro_use] extern crate log;
 #[cfg(test)] extern crate quickcheck;

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -5,8 +5,7 @@ use std::io::{Result, Error, ErrorKind};
 use util::{now_microseconds, ewma, abs_diff};
 use packet::{Packet, PacketType, Encodable, Decodable, ExtensionType, HEADER_SIZE};
 use rand::{self, Rng};
-use time::SteadyTime;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 // For simplicity's sake, let us assume no packet will ever exceed the
 // Ethernet maximum transfer unit of 1500 bytes.
@@ -388,7 +387,7 @@ impl UtpSocket {
 
     fn recv(&mut self, buf: &mut[u8]) -> Result<(usize, SocketAddr)> {
         let mut b = [0; BUF_SIZE + HEADER_SIZE];
-        let now = SteadyTime::now();
+        let start = Instant::now();
         let (read, src);
         let mut retries = 0;
 
@@ -416,8 +415,9 @@ impl UtpSocket {
                 Err(e) => return Err(e),
             };
 
-            let elapsed = (SteadyTime::now() - now).num_milliseconds();
-            debug!("{} ms elapsed", elapsed);
+            let elapsed = start.elapsed();
+            let elapsed_ms = elapsed.as_secs() * 1000 + (elapsed.subsec_nanos() / 1000_000) as u64;
+            debug!("{} ms elapsed", elapsed_ms);
             retries += 1;
         }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,13 @@
-use time;
+use std::time;
 use num::ToPrimitive;
 
 /// Return current time in microseconds since the UNIX epoch.
 pub fn now_microseconds() -> u32 {
-    let t = time::get_time();
-    (t.sec * 1_000_000 + t.nsec as i64 / 1000) as u32
+    let t = match time::SystemTime::now().duration_since(time::UNIX_EPOCH) {
+        Ok(dur) => dur,
+        Err(err) => err.duration(),
+    };
+    (t.as_secs().wrapping_mul(1_000_000) as u32).wrapping_add(t.subsec_nanos() / 1000)
 }
 
 /// Calculate the exponential weighted moving average for a vector of numbers, with a smoothing


### PR DESCRIPTION
…onds since unix epoch