### PR TITLE
Force PacketHeader's representation to be predictable

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -121,6 +121,7 @@ impl<'a> Extension<'a> {
     }
 }
 
+#[repr(C)]
 struct PacketHeader {
     type_ver: u8, // type: u4, ver: u4
     extension: u8,


### PR DESCRIPTION
This PR forces the `PacketHeader` representation to be `#[repr(C)]`. This fixes an issue where the compiler might reorder the struct's fields, which would mess up the unsafe cast to an array of bytes.

Currently waiting for the new Rust 15.0 beta to be released and tested against master.

Fixes #29 